### PR TITLE
Consistent polling

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -65,15 +65,15 @@ impl Check {
             ..Default::default()
         }
     }
-    pub fn mark_as_checked(&mut self) {
+    pub fn mark_as_checked(&mut self, time_of_check: &DateTime<Utc>) {
         self.is_checked = true;
-        self.time_of_check = Some(Utc::now())
+        self.time_of_check = Some(time_of_check.clone())
     }
 
-    pub fn progress_item(&mut self, snes_value: u8) {
+    pub fn progress_item(&mut self, snes_value: u8, time_of_check: &DateTime<Utc>) {
         self.progressive_level += 1;
         self.snes_value = snes_value;
-        self.time_of_check = Some(Utc::now());
+        self.time_of_check = Some(time_of_check.clone());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub struct CliConfig {
     non_race_mode: bool,
     manual_update: bool,
     update_frequency: u64,
+    _verbosity: u64,
 }
 
 pub fn connect_to_qusb(args: &ArgMatches) -> anyhow::Result<()> {
@@ -89,9 +90,8 @@ pub fn connect_to_qusb(args: &ArgMatches) -> anyhow::Result<()> {
             .unwrap()
             .parse()
             .expect("specified update frequency (--freq/-f) needs to be a positive integer"),
+        _verbosity: args.occurrences_of("v"),
     }));
-
-    let _verbosity = args.occurrences_of("v");
 
     let (tx, rx) = mpsc::channel();
 
@@ -115,8 +115,7 @@ pub fn connect_to_qusb(args: &ArgMatches) -> anyhow::Result<()> {
 
     let mut ram_history: VecDeque<SnesRam> = VecDeque::new();
 
-    let time_start = Utc::now();
-    let csv_name = time_start.format("%Y%m%d_%H%M%S.csv").to_string();
+    let csv_name = Utc::now().format("%Y%m%d_%H%M%S.csv").to_string();
     File::create(&csv_name)?;
     let mut writer = Writer::from_path(csv_name)?;
 
@@ -217,7 +216,6 @@ pub fn read_snes_ram(
                     if let Ok(connected_client) = connect(Arc::clone(&config)) {
                         client = connected_client;
                     }
-                    sleep(time::Duration::from_secs(1));
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,10 +38,6 @@ fn main() -> anyhow::Result<()> {
                 .short('m')
                 .about("Only check for updates when user presses a key. Useful when debugging.")
         ).arg(
-            Arg::new("game started")
-                .long("--game-started")
-                .about("Set this if you've already begun playing (i.e. spawned Link), as otherwise it might not start checking transitions for awhile")
-        ).arg(
             Arg::new("Non race mode")
                 .long("--non-race")
                 .about("Show output on game events in app window. NOTE: This flag will have no effect when playing a race rom.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
                 .short('f')
                 .about("Interval in milliseconds the timer will check the snes memory for changes. Default is about 60 times per second")
                 .takes_value(true)
-                .default_value("12")
+                .default_value("16")
         ).arg(
             Arg::new("v")
                 .short('v')

--- a/src/qusb.rs
+++ b/src/qusb.rs
@@ -136,9 +136,7 @@ pub fn init_meta_data(
     let mut client =
         ClientBuilder::new(&format!("ws://{}:{}", config.host, config.port))?.connect_insecure()?;
     println!("{} to qusb!", "Connected".green().bold());
-    let mut connected = false;
-    while !connected {
-        connected = attempt_qusb_connection(&mut client)?;
+    while !attempt_qusb_connection(&mut client)? {
         sleep(time::Duration::from_millis(2000));
     }
     *allow_output_rx.lock().unwrap() = match is_race_rom(&mut client) {
@@ -171,9 +169,7 @@ pub fn connect(
     let config = cli_config.lock().unwrap();
     let mut client =
         ClientBuilder::new(&format!("ws://{}:{}", config.host, config.port))?.connect_insecure()?;
-    let mut connected = false;
-    while !connected {
-        connected = attempt_qusb_connection(&mut client)?;
+    while !attempt_qusb_connection(&mut client)? {
         sleep(time::Duration::from_millis(2000));
     }
     Ok(client)

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -32,8 +32,8 @@ impl Tile {
         }
     }
 
-    pub fn time_transit(&mut self) {
-        self.timestamp = Some(Utc::now())
+    pub fn time_transit(&mut self, time_of_transition: &DateTime<Utc>) {
+        self.timestamp = Some(time_of_transition.clone())
     }
 
     pub fn try_from_ram(current: &SnesRam, previous_tile: &Tile) -> Result<Tile> {


### PR DESCRIPTION
This closes #8 

- polling of snes data is now running on its separate thread.
- Timestamps are created when the read thread has received all data from the snes (or rather qusb/sni).